### PR TITLE
Removing framework from dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "spiral/validator": "^1.0"
     },
     "require-dev": {
-        "spiral/framework": "^3.0",
         "phpunit/phpunit": "^9.5",
         "mockery/mockery": "^1.5",
         "vimeo/psalm": "^4.9"

--- a/src/Exception/InvalidFilterException.php
+++ b/src/Exception/InvalidFilterException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Filters\Exception;
+
+use Spiral\Core\Exception\ControllerException;
+use Spiral\Filters\FilterInterface;
+
+final class InvalidFilterException extends ControllerException
+{
+    private array $errors = [];
+
+    public function __construct(FilterInterface $filter)
+    {
+        $this->errors = $filter->getErrors();
+
+        parent::__construct(\sprintf('Invalid `%s`', $filter::class), self::BAD_ARGUMENT);
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Interceptor/FilterInterceptor.php
+++ b/src/Interceptor/FilterInterceptor.php
@@ -7,7 +7,7 @@ namespace Spiral\Filters\Interceptor;
 use Psr\Container\ContainerInterface;
 use Spiral\Core\CoreInterceptorInterface;
 use Spiral\Core\CoreInterface;
-use Spiral\Domain\Exception\InvalidFilterException;
+use Spiral\Filters\Exception\InvalidFilterException;
 use Spiral\Filters\FilterInterface;
 
 /**


### PR DESCRIPTION
Added `InvalidFilterException` because it was removed in SF 3.0.