### PR TITLE
Fix implicit nullable to prevent deprecation on PHP 8.4

### DIFF
--- a/src/ArrayInput.php
+++ b/src/ArrayInput.php
@@ -34,7 +34,7 @@ final class ArrayInput implements InputInterface
         return $input;
     }
 
-    public function getValue(string $source, string $name = null): mixed
+    public function getValue(string $source, ?string $name = null): mixed
     {
         try {
             return $this->dotGet($name);

--- a/src/Bootloader/FiltersBootloader.php
+++ b/src/Bootloader/FiltersBootloader.php
@@ -47,7 +47,7 @@ final class FiltersBootloader extends Bootloader implements InjectorInterface
         $this->registerCommands($console);
     }
 
-    public function createInjection(\ReflectionClass $class, string $context = null): object
+    public function createInjection(\ReflectionClass $class, ?string $context = null): object
     {
         return $this->container->get(FilterProviderInterface::class)->createFilter(
             $class->getName(),

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -99,7 +99,7 @@ abstract class Filter extends SchematicEntity implements FilterInterface
         $this->errors = null;
     }
 
-    public function setField(string $name, mixed $value, bool $filter = true): self
+    public function setField(string $name, mixed $value, ?bool $filter = true): self
     {
         parent::setField($name, $value, $filter);
         $this->reset();


### PR DESCRIPTION
## What was changed

Updated types delcaration to explicitly allow nullable where it is implicitly allowed.

## Why?

To prevent deprecation errors while running it on PHP 8.4:

```
PHP Deprecated:  Spiral\Filters\Bootloader\FiltersBootloader::createInjection(): Implicitly marking parameter $context as nullable is deprecated, the explicit nullable type must be used instead in (...)/vendor/spiral/filters-bridge/src/Bootloader/FiltersBootloader.php on line 50
```

## Checklist

- Tested
    - [x] Tested manually

